### PR TITLE
more header regex

### DIFF
--- a/lib/samples.js
+++ b/lib/samples.js
@@ -6,7 +6,7 @@ var Transform = require('stream').Transform;
 module.exports = Samples;
 
 // {executable name} {pid} {time}: cycles:
-var headerRegex = /(.+) (\d+) ([\d\.]+): cycles:/;
+var headerRegex = /(.+) (\d+(\/\d+)?) ([\d\.]+): +(\d+ )?cycles:/;
 // {address} {function name} ({shared object})
 var frameRegex = /\s*([0-9a-f]+) (.+) \((.+)\)/;
 


### PR DESCRIPTION
This makes the header regex accept the default `perf script` output on my system (Linux 4.9.11, perf 4.9.g69973b) as well as the original format described in the comment.